### PR TITLE
DL-1050:Fixed welsh toggle pushback issue.

### DIFF
--- a/app/forms/WithdrawDateForm.scala
+++ b/app/forms/WithdrawDateForm.scala
@@ -19,34 +19,38 @@ package forms
 import java.time.{LocalDate, LocalDateTime}
 
 import common.Dates
+import models.WithdrawDateFormModel
 import play.api.Play.current
 import play.api.data.Form
 import play.api.data.Forms._
 
 object WithdrawDateForm extends CommonBinders{
 
-  def withdrawDateForm: Form[(Option[Int], Option[Int], Option[Int])] = Form(
-    tuple(
+  def withdrawDateForm: Form[WithdrawDateFormModel] = Form(
+    mapping(
       "withdrawDay" -> withdrawDateFormatter,
       "withdrawMonth" -> withdrawDatePartialFormatter("month"),
       "withdrawYear" -> withdrawDatePartialFormatter("year")
-    )
+    )(WithdrawDateFormModel.apply)(WithdrawDateFormModel.unapply)
   )
 
-  def validateWithdrawDate(form: Form[(Option[Int], Option[Int], Option[Int])],
-                           protectionStartDate: LocalDateTime): Form[(Option[Int], Option[Int], Option[Int])] = {
+  def validateWithdrawDate(form: Form[WithdrawDateFormModel],
+                           protectionStartDate: LocalDateTime): Form[WithdrawDateFormModel] = {
     if (form.hasErrors) form else {
-      val day = form.get._1.get
-      val month = form.get._2.get
-      val year = form.get._3.get
+      val day = form.get.withdrawDay.get
+      val month = form.get.withdrawMonth.get
+      val year = form.get.withdrawYear.get
       if (LocalDate.of(year, month, day) isBefore protectionStartDate.toLocalDate)
         form.withError("", "pla.withdraw.date-input.form.date-before-start-date")
       else form
     }
   }
 
-  def getWithdrawDate(form: Form[(Option[Int], Option[Int], Option[Int])]) : String = {
-    Dates.apiDateFormat(form.get._1.get,form.get._2.get,form.get._3.get)
+  def getWithdrawDate(form: Form[WithdrawDateFormModel]) : String = {
+    Dates.apiDateFormat(form.get.withdrawDay.get,form.get.withdrawMonth.get,form.get.withdrawYear.get)
   }
 
+  def getWithdrawDateModel(form: WithdrawDateFormModel) : String = {
+    Dates.apiDateFormat(form.withdrawDay.get,form.withdrawMonth.get,form.withdrawYear.get)
+  }
 }

--- a/app/models/WithdrawDateFormModel.scala
+++ b/app/models/WithdrawDateFormModel.scala
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json._
+
+case class WithdrawDateFormModel (withdrawDay: Option[Int], withdrawMonth: Option[Int], withdrawYear: Option[Int])
+
+object WithdrawDateFormModel {
+  implicit val format: OFormat[WithdrawDateFormModel] = Json.format[WithdrawDateFormModel]
+}

--- a/app/views/pages/withdraw/withdrawConfirm.scala.html
+++ b/app/views/pages/withdraw/withdrawConfirm.scala.html
@@ -35,7 +35,7 @@
     @govHelpers.form(action = routes.WithdrawProtectionController.displayWithdrawConfirmation(withdrawDate)) {
 
 
-        <a class="back-link" style="margin-bottom: 0px" href=@routes.WithdrawProtectionController.withdrawDateInput()>Back</a>
+        <a class="back-link" style="margin-bottom: 0px" href=@routes.WithdrawProtectionController.getWithdrawDateInput()>Back</a>
 
 
         <h1 class="heading-large">@Messages(s"pla.withdraw.what-happens.info-heading")</h1>

--- a/app/views/pages/withdraw/withdrawDate.scala.html
+++ b/app/views/pages/withdraw/withdrawDate.scala.html
@@ -20,7 +20,7 @@
 @import play.api.Application
 @import uk.gov.hmrc.play.views.html.{helpers => govHelpers}
 
-@(withdrawDateForm: Form[(Option[Int], Option[Int], Option[Int])],protectionType: String, status: String)(implicit request: Request[_], messages: Messages, lang: Lang, application: Application, context: config.PlaContext, partialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever,  templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer)
+@(withdrawDateForm: Form[WithdrawDateFormModel], protectionType: String, status: String)(implicit request: Request[_], messages: Messages, lang: Lang, application: Application, context: config.PlaContext, partialRetriever: uk.gov.hmrc.play.partials.FormPartialRetriever,  templateRenderer: uk.gov.hmrc.renderer.TemplateRenderer)
 
 @lc = @{
     Application.instanceCache[PlaLanguageController].apply(application)
@@ -41,7 +41,7 @@
     @govHelpers.errorSummary(Messages("pla.base.errorSummaryLabel"), withdrawDateForm)
     }
 
-    @govHelpers.form(action = routes.WithdrawProtectionController.submitWithdrawDateInput()) {
+    @govHelpers.form(action = routes.WithdrawProtectionController.postWithdrawDateInput()) {
 
         <div class="inline form-group">
 

--- a/app/views/pages/withdraw/withdrawImplications.scala.html
+++ b/app/views/pages/withdraw/withdrawImplications.scala.html
@@ -47,7 +47,7 @@
 
     </div>
 
-    <a id="continue-button" class="button bold" role="button" type="submit" href=@routes.WithdrawProtectionController.withdrawDateInput()>@Messages("pla.withdraw.protection.continue.title")</a>
+    <a id="continue-button" class="button bold" role="button" type="submit" href=@routes.WithdrawProtectionController.getWithdrawDateInput()>@Messages("pla.withdraw.protection.continue.title")</a>
     <br />
     <br />
 

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -91,8 +91,13 @@ GET         /amend-protection/:protectionType/:status                           
 ## Withdraw protection ##
 #GET         /withdraw-protection/summary                                                  controllers.WithdrawProtectionController.withdrawSummary
 GET         /withdraw-protection/implications                                             @controllers.WithdrawProtectionController.withdrawImplications
-GET         /withdraw-protection/date-input                                               @controllers.WithdrawProtectionController.withdrawDateInput
-POST        /withdraw-protection/date-input                                               @controllers.WithdrawProtectionController.submitWithdrawDateInput
+
+GET         /withdraw-protection/date-input                                               @controllers.WithdrawProtectionController.getWithdrawDateInput
+POST        /withdraw-protection/date-input                                               @controllers.WithdrawProtectionController.postWithdrawDateInput
+
+GET         /withdraw-protection/date-input-confirmation                                  @controllers.WithdrawProtectionController.getSubmitWithdrawDateInput
+POST        /withdraw-protection/date-input-confirmation                                  @controllers.WithdrawProtectionController.submitWithdrawDateInput
+
 GET         /withdraw-protection/confirmation/:withdrawDate                               @controllers.WithdrawProtectionController.displayWithdrawConfirmation(withdrawDate)
 GET         /withdraw-protection/withdraw-confirmation/:protectionType                    @controllers.WithdrawProtectionController.showWithdrawConfirmation(protectionType)
 #PSA Lookup routes

--- a/test/views/pages/withdraw/WithdrawConfirmViewSpec.scala
+++ b/test/views/pages/withdraw/WithdrawConfirmViewSpec.scala
@@ -43,7 +43,7 @@ class WithdrawConfirmViewSpec extends CommonViewSpecHelper with WithdrawConfirmS
     }
 
     "have a back with href" in {
-      doc.select("a").attr("href") shouldBe routes.WithdrawProtectionController.withdrawDateInput().url
+      doc.select("a").attr("href") shouldBe routes.WithdrawProtectionController.getWithdrawDateInput().url
     }
 
     "have a form action of 'getAction'" in {

--- a/test/views/pages/withdraw/WithdrawImplicationsSpec.scala
+++ b/test/views/pages/withdraw/WithdrawImplicationsSpec.scala
@@ -71,7 +71,7 @@ class WithdrawImplicationsSpec extends CommonViewSpecHelper with WithdrawImplica
       }
 
       s"have a href" in {
-        button.attr("href") shouldBe routes.WithdrawProtectionController.withdrawDateInput().url
+        button.attr("href") shouldBe routes.WithdrawProtectionController.getWithdrawDateInput().url
       }
 
     }


### PR DESCRIPTION
# DL-1050:Fixed welsh toggle pushback issue.

**Bug fix** 
When withdrawing a protection, toggling language would reset the user back two a page if on the withdraw confirmation page. Stopped the two pages sharing a route. 

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [ ]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [ ]  I've run a dependency check to ensure all dependencies are up to date
