### PR TITLE
make sure date's month is displayed in Welsh

### DIFF
--- a/app/constructors/DisplayConstructors.scala
+++ b/app/constructors/DisplayConstructors.scala
@@ -37,7 +37,7 @@ class DisplayConstructors @Inject()() {
   def createPrintDisplayModel(personalDetailsModelOpt: Option[PersonalDetailsModel],
                               protectionModel: ProtectionModel,
                               nino: String
-                             ): PrintDisplayModel = {
+                             )(implicit lang: Lang): PrintDisplayModel = {
 
     val personalDetailsModel = personalDetailsModelOpt.getOrElse {
       throw new Exceptions.RequiredValueNotDefinedException("createPrintDisplayModel", "personalDetailsModel")
@@ -80,7 +80,7 @@ class DisplayConstructors @Inject()() {
   }
 
   // EXISTING PROTECTIONS
-  def createExistingProtectionsDisplayModel(model: TransformedReadResponseModel): ExistingProtectionsDisplayModel = {
+  def createExistingProtectionsDisplayModel(model: TransformedReadResponseModel)(implicit lang: Lang): ExistingProtectionsDisplayModel = {
     val activeProtection = model.activeProtection.map(createExistingProtectionDisplayModel)
     val otherProtectionsList = model.inactiveProtections.map(createExistingProtectionDisplayModel).sortWith(sortByStatus)
 
@@ -99,7 +99,7 @@ class DisplayConstructors @Inject()() {
     }
   }
 
-  def createExistingProtectionDisplayModel(model: ProtectionModel): ExistingProtectionDisplayModel = {
+  def createExistingProtectionDisplayModel(model: ProtectionModel)(implicit lang: Lang): ExistingProtectionDisplayModel = {
 
     val status = Strings.statusString(model.status)
     val protectionType = Strings.protectionTypeString(model.protectionType)
@@ -134,7 +134,7 @@ class DisplayConstructors @Inject()() {
   }
 
   // AMENDS
-  def createAmendDisplayModel(model: AmendProtectionModel): AmendDisplayModel = {
+  def createAmendDisplayModel(model: AmendProtectionModel)(implicit lang: Lang): AmendDisplayModel = {
     val amended = modelsDiffer(model.originalProtection, model.updatedProtection)
     val totalAmount = Display.currencyDisplayString(BigDecimal(
       model.updatedProtection.relevantAmount.getOrElse(0.0)
@@ -161,7 +161,7 @@ class DisplayConstructors @Inject()() {
     createNoChangeSection(model, ApplicationStage.CurrentPsos, model.pensionDebitTotalAmount)
   }
 
-  def createCurrentPsoSection(model: ProtectionModel): Option[Seq[AmendDisplaySectionModel]] = {
+  def createCurrentPsoSection(model: ProtectionModel)(implicit lang: Lang): Option[Seq[AmendDisplaySectionModel]] = {
 
     model.pensionDebits.flatMap { psoList =>
       if (psoList.length > 1) {
@@ -285,7 +285,7 @@ class DisplayConstructors @Inject()() {
   }
 
   // SUCCESSFUL APPLICATION RESPONSE
-  def createSuccessDisplayModel(model: ApplyResponseModel)(implicit protectionType: ApplicationType.Value): SuccessDisplayModel = {
+  def createSuccessDisplayModel(model: ApplyResponseModel)(implicit protectionType: ApplicationType.Value, lang: Lang): SuccessDisplayModel = {
     val notificationId = model.protection.notificationId.getOrElse(throw new Exceptions.OptionNotDefinedException("CreateSuccessDisplayModel", "notification ID", protectionType.toString))
     val protectedAmount = model.protection.protectedAmount.getOrElse(if (protectionType == ApplicationType.FP2016) Constants.fpProtectedAmount else throw new Exceptions.OptionNotDefinedException("ApplyResponseModel", "protected amount", protectionType.toString))
     val printable = Constants.activeProtectionCodes.contains(notificationId)
@@ -308,7 +308,7 @@ class DisplayConstructors @Inject()() {
     RejectionDisplayModel(notificationId.toString, additionalInfo, protectionType)
   }
 
-  private def createProtectionDetailsFromProtection(protection: ProtectionModel): ProtectionDetailsDisplayModel = {
+  private def createProtectionDetailsFromProtection(protection: ProtectionModel)(implicit lang: Lang): ProtectionDetailsDisplayModel = {
     val protectionReference = protection.protectionReference
     val psaReference = protection.psaCheckReference.getOrElse(throw new Exceptions.OptionNotDefinedException("createProtectionDetailsFromModel", "psaCheckReference", protection.protectionType.getOrElse("No protection type in response")))
     val applicationDate = protection.certificateDate.map { dt => Display.dateDisplayString(Dates.constructDateFromAPIString(dt)) }

--- a/app/controllers/AmendsController.scala
+++ b/app/controllers/AmendsController.scala
@@ -237,6 +237,7 @@ class AmendsController @Inject()(val keyStoreConnector: KeyStoreConnector,
   }
 
   def amendsSummary(protectionType: String, status: String): Action[AnyContent] = Action.async { implicit request =>
+    implicit val lang = mcc.messagesApi.preferred(request).lang
      authFunction.genericAuthWithNino("existingProtections") { nino =>
       val protectionKey = Strings.keyStoreAmendFetchString(protectionType, status)
       keyStoreConnector.fetchAndGetFormData[AmendProtectionModel](protectionKey).map {

--- a/app/controllers/PrintController.scala
+++ b/app/controllers/PrintController.scala
@@ -24,7 +24,7 @@ import constructors.DisplayConstructors
 import javax.inject.Inject
 import models.{PersonalDetailsModel, ProtectionModel}
 import play.api.Logger
-import play.api.i18n.I18nSupport
+import play.api.i18n.{I18nSupport, Lang}
 import play.api.mvc._
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
@@ -44,6 +44,7 @@ class PrintController @Inject()(val keyStoreConnector: KeyStoreConnector,
   lazy val postSignInRedirectUrl = appConfig.existingProtectionsUrl
 
   val printView = Action.async { implicit request =>
+    implicit val lang = mcc.messagesApi.preferred(request).lang
     authFunction.genericAuthWithNino("existingProtections") { nino =>
       for {
         personalDetailsModel <- citizenDetailsConnector.getPersonDetails(nino)
@@ -55,7 +56,7 @@ class PrintController @Inject()(val keyStoreConnector: KeyStoreConnector,
 
   private def routePrintView(personalDetailsModel: Option[PersonalDetailsModel],
                              protectionModel: Option[ProtectionModel],
-                             nino: String)(implicit request: Request[AnyContent]): Result = {
+                             nino: String)(implicit request: Request[AnyContent],lang: Lang): Result = {
     protectionModel match {
       case Some(model) =>
         val displayModel = displayConstructors.createPrintDisplayModel(personalDetailsModel, model, nino)

--- a/app/controllers/ResultController.scala
+++ b/app/controllers/ResultController.scala
@@ -27,7 +27,7 @@ import javax.inject.Inject
 import models._
 import play.api.Logger
 import play.api.Play.current
-import play.api.i18n.I18nSupport
+import play.api.i18n.{I18nSupport, Lang}
 import play.api.mvc._
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -109,6 +109,7 @@ class ResultController @Inject()(keyStoreConnector: KeyStoreConnector,
 
   def displayResult(implicit protectionType: ApplicationType.Value): Action[AnyContent] = Action.async {
     implicit request =>
+      implicit val lang = mcc.messagesApi.preferred(request).lang
       authFunction.genericAuthWithNino("existingProtections") { nino =>
         val showUserResearchPanel = setURPanelFlag
         val errorResponse = InternalServerError(views.html.pages.fallback.technicalError(protectionType.toString)).withHeaders(CACHE_CONTROL -> "no-cache")

--- a/project/FrontendBuild.scala
+++ b/project/FrontendBuild.scala
@@ -27,20 +27,20 @@ private object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val bootstrapVersion = "0.37.0"
-  private val govukTemplateVersion = "5.30.0-play-26"
-  private val playUiVersion = "7.37.0-play-26"
+  private val bootstrapVersion = "0.38.0"
+  private val govukTemplateVersion = "5.31.0-play-26"
+  private val playUiVersion = "7.38.0-play-26"
   private val playPartialsVersion = "6.7.0-play-26"
-  private val hmrcTestVersion = "3.6.0-play-26"
+  private val hmrcTestVersion = "3.7.0-play-26"
   private val scalaTestVersion = "3.0.0"
   private val scalaTestPlusVersion = "3.1.2"
   private val pegdownVersion = "1.6.0"
-  private val cachingClientVersion = "8.1.0"
-  private val mongoCachingVersion = "6.2.0-play-26"
+  private val cachingClientVersion = "8.2.0"
+  private val mongoCachingVersion = "6.3.0-play-26"
   private val playLanguageVersion = "3.4.0"
   private val authClientVersion = "2.20.0-play-26"
   private val localTemplateRendererVersion = "2.4.0"
-  private val wireMockVersion          = "2.9.0"
+  private val wireMockVersion          = "2.22.0"
 
   val compile = Seq(
     ws,
@@ -68,7 +68,7 @@ private object AppDependencies {
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
         "org.jsoup" % "jsoup" % "1.11.3" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
-        "org.mockito" % "mockito-core" % "2.18.3" % scope
+        "org.mockito" % "mockito-core" % "2.27.0" % scope
       )
     }.test
   }
@@ -82,10 +82,10 @@ private object AppDependencies {
         "uk.gov.hmrc" %% "hmrctest" % hmrcTestVersion % scope,
         "org.scalatest" %% "scalatest" % scalaTestVersion % scope,
         "org.pegdown" % "pegdown" % pegdownVersion % scope,
-        "org.jsoup" % "jsoup" % "1.7.3" % scope,
+        "org.jsoup" % "jsoup" % "1.11.3" % scope,
         "com.typesafe.play" %% "play-test" % PlayVersion.current % scope,
         "org.scalatestplus.play" %% "scalatestplus-play" % scalaTestPlusVersion % scope,
-        "org.mockito" % "mockito-core" % "2.19.0" % scope,
+        "org.mockito" % "mockito-core" % "2.27.0" % scope,
         "com.github.tomakehurst"  %  "wiremock" % wireMockVersion % scope, 
         "com.github.tomakehurst" % "wiremock-jre8" % "2.22.0" % "test,it"
 

--- a/test/controllers/AmendsControllerSpec.scala
+++ b/test/controllers/AmendsControllerSpec.scala
@@ -257,7 +257,7 @@ class AmendsControllerSpec extends UnitSpec with MockitoSugar with KeystoreTestH
     "there is a stored, updated amends model" in new Setup {
       mockAuthRetrieval[Option[String]](Retrievals.nino, Some("AB123456A"))
       keystoreFetchCondition[AmendProtectionModel](Some(testAmendIP2014ProtectionModel))
-      when(mockDisplayConstructors.createAmendDisplayModel(ArgumentMatchers.any())).thenReturn(tstAmendDisplayModel)
+      when(mockDisplayConstructors.createAmendDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(tstAmendDisplayModel)
 
       val result = await(controller.amendsSummary("ip2014", "dormant")(fakeRequest))
       val jsoupDoc = Jsoup.parse(bodyOf(result))

--- a/test/controllers/PrintControllerSpec.scala
+++ b/test/controllers/PrintControllerSpec.scala
@@ -93,7 +93,7 @@ class PrintControllerSpec extends UnitSpec with MockitoSugar with AuthMock with 
           .thenReturn(Future.successful(Some(testPersonalDetails)))
         when(mockKeyStoreConnector.fetchAndGetFormData[ProtectionModel](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
           .thenReturn(Future.successful(Some(testProtectionModel)))
-        when(mockDisplayConstructors.createPrintDisplayModel(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+        when(mockDisplayConstructors.createPrintDisplayModel(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
           .thenReturn(testPrintDisplayModel)
 
         val result = await(TestPrintController.printView(fakeRequest))
@@ -107,7 +107,7 @@ class PrintControllerSpec extends UnitSpec with MockitoSugar with AuthMock with 
           .thenReturn(Future(Some(testPersonalDetails)))
         when(mockKeyStoreConnector.fetchAndGetFormData[ProtectionModel](ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
           .thenReturn(None)
-        when(mockDisplayConstructors.createPrintDisplayModel(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any()))
+        when(mockDisplayConstructors.createPrintDisplayModel(ArgumentMatchers.any(), ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any()))
           .thenReturn(testPrintDisplayModel)
 
         val result = await(TestPrintController.printView(fakeRequest))

--- a/test/controllers/ReadProtectionsControllerSpec.scala
+++ b/test/controllers/ReadProtectionsControllerSpec.scala
@@ -142,14 +142,14 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
         "provided with no protection model" in new Setup{
           when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
           when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-          when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+          when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
           await(controller.saveActiveProtection(None)(fakeRequest)) shouldBe true
         }
 
         "provided with a protection model" in new Setup {
           when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
           when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-          when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+          when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
           when(mockKeyStoreConnector.saveData(ArgumentMatchers.any(), ArgumentMatchers.any())(ArgumentMatchers.any(), ArgumentMatchers.any()))
             .thenReturn(Future.successful(mock[CacheMap]))
           await(controller.saveActiveProtection(Some(ip2016Protection))(fakeRequest)) shouldBe true
@@ -162,7 +162,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections exist" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(None, Seq())
 
         controller.getAmendableProtections(model) shouldBe Seq()
@@ -171,7 +171,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(nonAmendableProtection, nonAmendableProtection))
 
         controller.getAmendableProtections(model) shouldBe Seq()
@@ -180,7 +180,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a single element if only the active protection is amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(nonAmendableProtection, nonAmendableProtection))
 
         controller.getAmendableProtections(model) shouldBe Seq(ip2016Protection)
@@ -189,7 +189,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return all inactive elements if only they are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(ip2016Protection, ip2016Protection))
 
         controller.getAmendableProtections(model) shouldBe Seq(ip2016Protection, ip2016Protection)
@@ -198,7 +198,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return all elements if they are all amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(ip2016Protection, ip2016Protection))
 
         controller.getAmendableProtections(model) shouldBe Seq(ip2016Protection, ip2016Protection, ip2016Protection)
@@ -210,7 +210,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections exist" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(None, Seq())
         mockKeystoreSave
         await(controller.saveAmendableProtections(model)(fakeRequest)) shouldBe Seq()
@@ -219,7 +219,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(nonAmendableProtection, nonAmendableProtection))
         mockKeystoreSave
         await(controller.saveAmendableProtections(model)(fakeRequest)) shouldBe Seq()
@@ -228,7 +228,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a single cache map if only the active protection is amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(nonAmendableProtection, nonAmendableProtection))
         mockKeystoreSave
         await(controller.saveAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap)
@@ -237,7 +237,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a cache map per inactive elements if only they are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(ip2016Protection, ip2016Protection))
         mockKeystoreSave
         await(controller.saveAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap, mockCacheMap)
@@ -246,7 +246,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a cache map per element if they are all amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(ip2016Protection, ip2016Protection))
         mockKeystoreSave
         await(controller.saveAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap, mockCacheMap, mockCacheMap)
@@ -258,7 +258,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections exist" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(None, Seq())
 
         controller.getNonAmendableProtections(model) shouldBe Seq()
@@ -267,7 +267,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if all protections are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(ip2016Protection, ip2016Protection))
 
         controller.getNonAmendableProtections(model) shouldBe Seq()
@@ -276,7 +276,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a single element if only the active protection is non-amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(ip2016Protection, ip2016Protection))
 
         controller.getNonAmendableProtections(model) shouldBe Seq(nonAmendableProtection)
@@ -285,7 +285,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return all inactive elements if only they are non-amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(nonAmendableProtection, nonAmendableProtection))
 
         controller.getNonAmendableProtections(model) shouldBe Seq(nonAmendableProtection, nonAmendableProtection)
@@ -294,7 +294,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return all elements if they are all non-amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(nonAmendableProtection, nonAmendableProtection))
 
         controller.getNonAmendableProtections(model) shouldBe Seq(nonAmendableProtection, nonAmendableProtection, nonAmendableProtection)
@@ -306,7 +306,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections exist" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(None, Seq())
         mockKeystoreSave
         await(controller.saveNonAmendableProtections(model)(fakeRequest)) shouldBe Seq()
@@ -315,7 +315,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return an empty sequence if no protections are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(ip2016Protection, ip2016Protection))
         mockKeystoreSave
         await(controller.saveNonAmendableProtections(model)(fakeRequest)) shouldBe Seq()
@@ -324,7 +324,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a single cache map if only the active protection is amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(ip2016Protection, ip2016Protection))
         mockKeystoreSave
         await(controller.saveNonAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap)
@@ -333,7 +333,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a cache map per inactive elements if only they are amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(ip2016Protection), Seq(nonAmendableProtection, nonAmendableProtection))
         mockKeystoreSave
         await(controller.saveNonAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap, mockCacheMap)
@@ -342,7 +342,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return a cache map per element if they are all amendable" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         val model = TransformedReadResponseModel(Some(nonAmendableProtection), Seq(nonAmendableProtection, nonAmendableProtection))
         mockKeystoreSave
         await(controller.saveNonAmendableProtections(model)(fakeRequest)) shouldBe Seq(mockCacheMap, mockCacheMap, mockCacheMap)
@@ -354,7 +354,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return 500 and show the technical error page for existing protections" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testUpstreamErrorResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         mockAuthRetrieval[Option[String]](Retrievals.nino, Some("AB123456A"))
 
 
@@ -369,7 +369,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return 423 and show the MC Needed page" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testMCNeededResponse)
         val result = await(controller.currentProtections(fakeRequest))
         status(result) shouldBe 423
@@ -380,7 +380,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return 500 and show the technical error page for existing protections" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(None)
 
@@ -396,7 +396,7 @@ class ReadProtectionsControllerSpec extends UnitSpec with MockitoSugar with Auth
       "return 200 and show the existing protections page" in new Setup {
         when(mockPlaConnector.readProtections(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testSuccessResponse)
         when(mockResponseConstructors.createTransformedReadResponseModelFromJson(ArgumentMatchers.any())).thenReturn(Some(testTransformedReadResponseModel))
-        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
+        when(mockDisplayConstructors.createExistingProtectionsDisplayModel(ArgumentMatchers.any())(ArgumentMatchers.any())).thenReturn(testExistingProtectionsDisplayModel)
 
         mockAuthRetrieval[Option[String]](Retrievals.nino, Some("AB123456A"))
         val result = await(controller.currentProtections(fakeRequest))

--- a/test/controllers/ResultControllerSpec.scala
+++ b/test/controllers/ResultControllerSpec.scala
@@ -232,7 +232,7 @@ class ResultControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       when(mockKeyStoreConnector.fetchAndGetFormData[ApplyResponseModel](any())(any(), any()))
         .thenReturn(Some(testFPSuccessApplyResponseModel))
 
-      when(mockDisplayConstructors.createSuccessDisplayModel(any())(any())).thenReturn(SuccessDisplayModel(
+      when(mockDisplayConstructors.createSuccessDisplayModel(any())(any(),any())).thenReturn(SuccessDisplayModel(
         ApplicationType.FP2016, "12313123", "50", true, None, Nil
       ))
 
@@ -308,7 +308,7 @@ class ResultControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
       when(mockKeyStoreConnector.fetchAndGetFormData[ApplyResponseModel](any())(any(), any()))
         .thenReturn(Some(testIP16SuccessApplyResponseModel))
 
-      when(mockDisplayConstructors.createSuccessDisplayModel(any())(any())).thenReturn(SuccessDisplayModel(
+      when(mockDisplayConstructors.createSuccessDisplayModel(any())(any(),any())).thenReturn(SuccessDisplayModel(
         ApplicationType.FP2016, "12313123", "50", true, None, Nil
       ))
 
@@ -402,7 +402,7 @@ class ResultControllerSpec extends UnitSpec with MockitoSugar with BeforeAndAfte
         when(mockKeyStoreConnector.fetchAndGetFormData[ApplyResponseModel](any())(any(), any()))
           .thenReturn(Some(testIP16InactiveSuccessApplyResponseModel))
 
-        when(mockDisplayConstructors.createSuccessDisplayModel(any())(any())).thenReturn(SuccessDisplayModel(
+        when(mockDisplayConstructors.createSuccessDisplayModel(any())(any(),any())).thenReturn(SuccessDisplayModel(
           ApplicationType.FP2016, "12313123", "50", true, None, Nil
         ))
 


### PR DESCRIPTION
# Fix for bug introduce by play 2.6 upgrade

**Bug fix**

Changes made for the Play 2.6 upgrade re-introduced a bug that was fixed previously where when the user selects Welsh, the month in dates would still be in English. This fixes the issue
 
## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
