### PR TITLE
DL-1405 PLA Google Tag Manager (GTM) Migration

### DIFF
--- a/app/config/frontendAppConfig.scala
+++ b/app/config/frontendAppConfig.scala
@@ -49,6 +49,7 @@ trait AppConfig {
   val notFoundStatusMetric: String
   val appName : String
   val frontendTemplatePath: String
+  val googleTagManagerId: String
 }
 
 class FrontendAppConfig @Inject()(val configuration: Configuration, val servicesConfig: ServicesConfig) extends AppConfig {
@@ -90,5 +91,6 @@ class FrontendAppConfig @Inject()(val configuration: Configuration, val services
 
   override lazy val appName: String = loadConfig("appName")
   lazy val frontendTemplatePath: String = configuration.getString("microservice.services.frontend-template-provider.path").getOrElse("/template/mustache")
+  lazy val googleTagManagerId = loadConfig(s"google-tag-manager.id")
 
 }

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -115,6 +115,13 @@ if(str.trim=="") false else str
     false
 }
 
+@googleTagManager = @{ if(appConfig.googleTagManagerId != "N/A") {
+        Map("gtmId" -> appConfig.googleTagManagerId)
+    } else {
+        false
+    }
+}
+
 @{
 templateRenderer.renderDefaultTemplate(appConfig.frontendTemplatePath,article, Map[String, Any](
     "pageTitle" -> title,
@@ -125,6 +132,7 @@ templateRenderer.renderDefaultTemplate(appConfig.frontendTemplatePath,article, M
     "mainContentHeader" -> mainContentHeader,
 
     "googleAnalytics" -> googleAnalytics,
+    "googleTagManager" -> googleTagManager,
     "ssoUrl" -> None,
 
     "betaBanner" -> betaHeaderEnable,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -66,7 +66,7 @@ GET         /result-fp16                                                        
 POST        /result-ip16                                                                  @controllers.ResultController.processIPApplication
 GET         /result-ip16                                                                  @controllers.ResultController.displayIP16
 
-GET         /existing-protections                                                         @controllers.ReadProtectionsController.currentProtections
+    GET         /existing-protections                                                         @controllers.ReadProtectionsController.currentProtections
 GET         /print-protection                                                             @controllers.PrintController.printView
 
 ## Amends ##

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -38,6 +38,8 @@ sso.encryption.key="P5xsJ9Nt+quxGZzB4DeLfw=="
 
 play.ws.acceptAnyCertificate=true
 
+play.ws.ahc.maxNumberOfRedirects=10
+
 cookie.deviceId.secret="some_secret"
 
 # An ApplicationLoader that uses Guice to bootstrap the application.

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -73,7 +73,7 @@ play.http.session.cookieName="mdtp"
 
 session.timeoutSeconds =1800
 
-play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9310 localhost:9032 localhost:9250 www.google-analytics.com data:"
+play.filters.headers.contentSecurityPolicy= "default-src 'self' 'unsafe-inline' localhost:9310 localhost:9032 localhost:9250 www.google-analytics.com www.googletagmanager.com fonts.googleapis.com tagmanager.google.com ssl.gstatic.com www.gstatic.com fonts.gstatic.com data:"
 
 
 play.filters.csrf.header.bypassHeaders {
@@ -310,6 +310,10 @@ microservice {
 
 
     }
+}
+
+google-tag-manager {
+    id = "N/A"
 }
 
 contact-frontend {

--- a/test/auth/MockConfig.scala
+++ b/test/auth/MockConfig.scala
@@ -46,5 +46,5 @@ object MockConfig extends AppConfig {
   override val notFoundStatusMetric: String = ""
   override val appName: String = ""
   override val frontendTemplatePath: String = ""
-
+  override val googleTagManagerId: String = "N/A"
 }


### PR DESCRIPTION
[DL-1405]

Added Google Tag Manager functionality to the PLA front-end. Also increased the maxRedirects of the AsyncHttpClient from 5 to 10, as local unit tests were failing by reaching the maximum redirect limit.

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
