### PR TITLE
DL-4831 - pensions-lifetime-allowance-frontend doesn't handle identity-verification 404s

### DIFF
--- a/app/connectors/IdentityVerificationConnector.scala
+++ b/app/connectors/IdentityVerificationConnector.scala
@@ -18,12 +18,12 @@ package connectors
 
 import config.FrontendAppConfig
 import enums.IdentityVerificationResult.IdentityVerificationResult
+
 import javax.inject.Inject
 import play.api.libs.json.Json
 import services.MetricsService
-import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpReadsInstances, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
-import uk.gov.hmrc.http.HttpReads.Implicits._
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -35,6 +35,8 @@ class IdentityVerificationConnector @Inject() (appConfig: FrontendAppConfig, htt
   private def url(journeyId: String) = s"$serviceUrl/mdtp/journey/journeyId/$journeyId"
   private[connectors] case class IdentityVerificationResponse(result: IdentityVerificationResult)
   private implicit val formats = Json.format[IdentityVerificationResponse]
+
+  implicit val legacyRawReads = HttpReadsInstances.throwOnFailure(HttpReadsInstances.readEitherOf(HttpReadsInstances.readRaw))
 
   def identityVerificationResponse(journeyId: String)(implicit hc: HeaderCarrier): Future[IdentityVerificationResult] = {
     val context = MetricsService.identityVerificationTimer.time()

--- a/app/controllers/UnauthorisedController.scala
+++ b/app/controllers/UnauthorisedController.scala
@@ -20,13 +20,15 @@ import config.wiring.PlaFormPartialRetriever
 import config.{FrontendAppConfig, LocalTemplateRenderer, PlaContext}
 import connectors.{IdentityVerificationConnector, KeyStoreConnector}
 import enums.IdentityVerificationResult
+
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import play.api.{Application, Logger}
-import uk.gov.hmrc.http.NotFoundException
+import uk.gov.hmrc.http.{NotFoundException, Upstream4xxResponse}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.pages.ivFailure._
+
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -63,7 +65,7 @@ class UnauthorisedController @Inject()(identityVerificationConnector: IdentityVe
           Logger.info("Unauthorised identity verification, returned to unauthorised page")
           Future.successful(Unauthorized(unauthorised()))
       } recover {
-        case e: NotFoundException =>
+        case Upstream4xxResponse(_, NOT_FOUND, _, _) =>
           Logger.warn("Could not find unauthorised journey ID")
           Unauthorized(unauthorised())
       }

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,5 @@
 import uk.gov.hmrc.DefaultBuildSettings.{defaultSettings, scalaSettings, targetJvm}
 import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
-import uk.gov.hmrc.SbtArtifactory
 import com.typesafe.sbt.web.Import.pipelineStages
 import com.typesafe.sbt.web.Import.Assets
 import com.typesafe.sbt.digest.Import.digest
@@ -34,7 +33,7 @@ lazy val scoverageSettings = {
 }
 
 lazy val root = Project(appName, file("."))
-  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin, SbtArtifactory) ++ plugins: _*)
+  .enablePlugins(Seq(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin) ++ plugins: _*)
   .disablePlugins(JUnitXmlReportPlugin)
   .settings(playSettings ++ scoverageSettings: _*)
   .settings(scalaSettings: _*)
@@ -65,3 +64,4 @@ lazy val root = Project(appName, file("."))
     parallelExecution in IntegrationTest := false)
   .settings(resolvers ++= Seq(Resolver.bintrayRepo("hmrc", "releases"), Resolver.jcenterRepo))
   .settings(majorVersion := 2)
+  PlayKeys.playDefaultPort := 9010

--- a/it/IdentityVerificationConnectorSpec.scala
+++ b/it/IdentityVerificationConnectorSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import connectors.IdentityVerificationConnector
+import org.scalatestplus.play.guice.GuiceOneServerPerSuite
+import play.mvc.Http.Status.NOT_FOUND
+import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+import uk.gov.hmrc.play.test.UnitSpec
+import utils.{IntegrationBaseSpec, MockedAudit, WiremockHelper}
+
+class IdentityVerificationConnectorSpec extends UnitSpec with GuiceOneServerPerSuite with IntegrationBaseSpec with MockedAudit {
+
+  override val additionalConfiguration = Seq("microservice.services.identity-verification.port" -> WiremockHelper.wiremockPort)
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+
+  lazy val missingJourneyId = "1234aa56-7a8a-901a-23aa-aa4a56a78aa9"
+  lazy val identityVerificationConnector: IdentityVerificationConnector = app.injector.instanceOf[IdentityVerificationConnector]
+
+  "IdentityVerificationConnector" should {
+    "throw an UpstreamErrorResponse with a statusCode of NOT_FOUND" when {
+      "IV returns a 404" in {
+        stubGet(s"/mdtp/journey/journeyId/$missingJourneyId", NOT_FOUND, s"No journey found for the supplied journeyId = $missingJourneyId")
+
+        val thrown = intercept[UpstreamErrorResponse] {
+          await(identityVerificationConnector.identityVerificationResponse(missingJourneyId))
+        }
+
+        thrown.statusCode shouldBe NOT_FOUND
+      }
+    }
+
+  }
+
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -5,9 +5,9 @@ object AppDependencies {
   import play.sbt.PlayImport._
   import play.core.PlayVersion
 
-  private val bootstrapVersion = "2.1.0"
+  private val bootstrapVersion = "2.3.0"
   private val govukTemplateVersion = "5.60.0-play-26"
-  private val playUiVersion = "8.17.0-play-26"
+  private val playUiVersion = "8.20.0-play-26"
   private val playPartialsVersion = "7.0.0-play-26"
   private val hmrcTestVersion = "3.9.0-play-26"
   private val scalaTestVersion = "3.0.9"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,11 +8,11 @@ resolvers += "HMRC Releases" at "https://dl.bintray.com/hmrc/releases"
 
 resolvers += Resolver.url("scoverage-bintray", url("https://dl.bintray.com/sksamuel/sbt-plugins/"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.9.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "2.13.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.1.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.0.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
 addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.6.25")
 
@@ -21,8 +21,6 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-digest" % "1.1.4")
-
-addSbtPlugin("uk.gov.hmrc" % "sbt-artifactory" % "1.8.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 


### PR DESCRIPTION
# DL-4831 - pensions-lifetime-allowance-frontend doesn't handle identity-verification 404s

To run the integration tests: `sbt it:test`

- Added a Wiremock test for IdentityVerification 404s
- Updated UnauthorisedController to handle UpstreamErrorResponse exceptions
- Added default port (9010) to sbt settings
- Removed sbt-artifactory: https://confluence.tools.tax.service.gov.uk/display/TEC/2021/01/18/Removing+the+sbt-artifactory+plugin

## Checklist

 - [x]  I've made every effort to commit high quality, clean code and I have executed relevant static analyses to be sure
 - [x]  I've included appropriate tests with any code I've added (Unit, Integration, Acceptance etc.)
 - [x]  I've executed the acceptance test pack locally to ensure there are no functional regressions
 - [x]  I've added my code using logical, atomic commits, squashing as appropriate - including the JIRA issue number in the commit message
 - [x]  I've run a dependency check to ensure all dependencies are up to date
